### PR TITLE
build(workflow): fix workflow trigger to prevent multiple action runs to trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Core-API | Maven-deployer
 
 on:
   release: # Triggers this workflow whenever a new release is created.
-    type: [published]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
Fix typo in line 8 of the build.yml-workflow which used to be executed three times whenever a new release is created.