### PR TITLE
docs(readme): add note about currently missing wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
 # ![Logo](https://cdn.minevalley.eu/branding/logo_64px_cropped.png) - Core API 
 This api grants important features and access to the internal server-core of MineValleyEU, that is used in any module.
 
-This README.md is intended to help you with your daily issues or questions referring to our core and its components. It should offer you the most important information and give you answers to your upcoming questions. If this isn't the case sometimes, feel free to contact us on Discord.
-
-We do our best to update this documentary. There's no other source of information, that is more up-to-date, than this one. If there is any missing information or mistake in this README or if you should have any suggestions, please create a new issue, thank you!
+The wiki to this api is still work in progress.
 
 > **Core API**:
 >
 > version: _1.278.1_
 >
 > latest change: _12.01.2024_
-
-
-### Documentation
-There will be comprehensive documentation in the "Wiki" tab


### PR DESCRIPTION
Since there is no wiki in the readme or in the wiki tab, the information given here is incorrect and has been replaced by information that the wiki is currently still in progress.