### PR TITLE
ops: add general build workflow for nightly and release versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,31 +1,32 @@
-name: Core-API | Maven-deployer
-
-# This workflow is used to deploy a new maven-build of this api, whenever a new release is created.
-# Always make sure to delete the latest package before creating a new release!
+name: Core-API | Build and deploy
 
 on:
-  release: # Triggers this workflow whenever a new release is created.
-    type: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: 'The version of the new build.'
+        required: true
+        type: string
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
-      - name: Repository-Checkout
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      # Sets the current Java-version to 1.8.
       - name: Set up to JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8.0
+          distribution: 'temurin'
+          cache: 'maven'
+          java-version: 8
 
-      # Deploys a maven-build as a new package to be accessed with any pom.xml.
-      - name: Deploy to GitHub
-        run: |
-          mvn source:jar
-          mvn deploy
+      - name: Build with Maven
+        run: mvn source:jar -DapiVersion=${{ inputs.version }}
+
+      - name: Deploy to GitHub Packages # Repository is set in pom.xml
+        run: mvn deploy
         env:
           GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,14 @@ on:
         description: 'The version of the new build.'
         required: true
         type: string
+      isRelease:
+        description: 'Is this a release build?'
+        required: true
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   build:
@@ -23,10 +31,22 @@ jobs:
           cache: 'maven'
           java-version: 8
 
+      - name: Set Project Version
+        run: mvn versions:set -DnewVersion=${{ inputs.version }}
+
       - name: Build with Maven
-        run: mvn source:jar -DapiVersion=${{ inputs.version }}
+        run: mvn -B clean package
 
       - name: Deploy to GitHub Packages # Repository is set in pom.xml
         run: mvn deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload assets to release
+        if: ${{ inputs.isRelease }}
+        uses: softprops/action-gh-release@v0.1.15
+        with: 
+          files: |
+            target/api-${{ inputs.version }}.jar
+            target/api-${{ inputs.version }}-sources.jar
+            target/api-${{ inputs.version }}-javadoc.jar

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -3,34 +3,45 @@ name: Core-API | Nightly Builder
 on:
   push:
     branches:
-      - master
+      - '**'
 
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to build'
-        required: true
-        type: string
 
 jobs:
-  get-version:
-    name: Get version
+  get-latest-version:
+    name: Get latest version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.set-version-push.outputs.version || steps.set-version.outputs.version }}
+      version: ${{ steps.version-ready.outputs.release  }}
     steps:
-      - name: Set short commit hash on push
+      - name: Get latest release version
         if: github.event_name == 'push'
-        id: set-version-push
-        run: echo ::set-output name=version::$(git rev-parse --short HEAD)
-      - name: Set version from input
-        if: github.event_name == 'workflow_dispatch'
-        id: set-version
-        run: echo ::set-output name=version::${{ github.event.inputs.version }}
+        id: get-latest-version
+        uses: pozetroninc/github-action-get-latest-release@v0.7.0
+        with:
+          repository: ${{ github.repository }}
+
+      - name: Increment version
+        if: github.event_name == 'push'
+        id: increment-version
+        run: |
+          RELEASE_NAME=${{ steps.get-latest-version.outputs.release }}
+          echo "release=$(echo ${RELEASE_NAME#v} | awk -F. -v OFS=. '{$NF = $NF + 1;} 1')" >> "$GITHUB_OUTPUT"
+
+      - name: Set output
+        id: version-ready
+        
+        run: |
+          if [[ "${{ github.ref_name}}" == "main" || "${{ github.ref_name }}" == "master" ]]; then
+            echo "release=${{ steps.increment-version.outputs.release }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "release=${{ github.ref_name }}_${{ steps.increment-version.outputs.release }}" >> "$GITHUB_OUTPUT"
+          fi
 
   build-nightly:
     name: Build Nightly version
-    needs: get-version
+    needs: get-latest-version
     uses: ./.github/workflows/build.yml
     with:
-      version: ${{ needs.get-version.outputs.version }}
+      version: ${{ needs.get-latest-version.outputs.version }}-SNAPSHOT
+      isRelease: false

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,36 @@
+name: Core-API | Nightly Builder
+
+on:
+  push:
+    branches:
+      - master
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build'
+        required: true
+        type: string
+
+jobs:
+  get-version:
+    name: Get version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version-push.outputs.version || steps.set-version.outputs.version }}
+    steps:
+      - name: Set short commit hash on push
+        if: github.event_name == 'push'
+        id: set-version-push
+        run: echo ::set-output name=version::$(git rev-parse --short HEAD)
+      - name: Set version from input
+        if: github.event_name == 'workflow_dispatch'
+        id: set-version
+        run: echo ::set-output name=version::${{ github.event.inputs.version }}
+
+  build-nightly:
+    name: Build Nightly version
+    needs: get-version
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,7 +15,7 @@ jobs:
         id: get-version
         run: |
           TAG_NAME=${{ github.event.release.tag_name }}
-          echo ::set-output name=version::${TAG_NAME#v}
+          echo "version=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
 
   build-release:
     name: Build Release
@@ -23,5 +23,4 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.get-version.outputs.version }}
-
-    
+      isRelease: true

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,27 @@
+name: Core-API | Release Builder
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  get-version:
+    name: Get Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Get Version
+        id: get-version
+        run: |
+          TAG_NAME=${{ github.event.release.tag_name }}
+          echo ::set-output name=version::${TAG_NAME#v}
+
+  build-release:
+    name: Build Release
+    needs: get-version
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ needs.get-version.outputs.version }}
+
+    

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
     </distributionManagement>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        
         <smart-api.version>1.60</smart-api.version>
 
         <maven.compiler.source>8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,15 @@
             <id>github</id>
             <name>GitHub MineValley Apache Maven Packages</name>
             <url>https://maven.pkg.github.com/MineValley/Core-API</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        
+
         <smart-api.version>1.60</smart-api.version>
 
         <maven.compiler.source>8</maven.compiler.source>


### PR DESCRIPTION
Introduce a new general build workflow that supports both nightly and release versions.

Trigger the nightly workflow on any push to any branch, incrementing the last numeric version by one based on the latest release version. If the pushed branch is not 'master' or 'main', append the branch name before the numeric version. Suffix the resulting version with `-SNAPSHOT` and deploy it to GitHub Packages.

Activate the release workflow when publishing a new release. Extract the tag name, remove any 'v' prefix, and use it as the version number to build the Java project. Deploy the built files to GitHub Packages and add them as assets to the release.