### PR TITLE
feat(fake-armorstands): remove updateVisibility()-method

### DIFF
--- a/src/main/java/minevalley/core/api/utils/armorstand/modifiers/VisibilityModifier.java
+++ b/src/main/java/minevalley/core/api/utils/armorstand/modifiers/VisibilityModifier.java
@@ -70,9 +70,4 @@ public interface VisibilityModifier {
      * @return this
      */
     VisibilityModifier emptyHideList();
-
-    /**
-     * Updates the visibility of the armorstand.
-     */
-    void updateVisibility();
 }


### PR DESCRIPTION
Since the visibility of fake armor stands is updated dynamically, manual updating is no longer necessary.